### PR TITLE
add JaCoCo code coverage reports

### DIFF
--- a/prototype/pom.xml
+++ b/prototype/pom.xml
@@ -29,6 +29,28 @@
         </plugin>
     </plugins>
     </pluginManagement>
+    <plugins>
+        <plugin>
+            <groupId>org.jacoco</groupId>
+            <artifactId>jacoco-maven-plugin</artifactId>
+            <version>0.7.5.201505241946</version>
+            <executions>
+                <execution>
+                    <id>default-prepare-agent</id>
+                    <goals>
+                        <goal>prepare-agent</goal>
+                    </goals>
+                </execution>
+                <execution>
+                    <id>default-report</id>
+                    <phase>test</phase>
+                    <goals>
+                        <goal>report</goal>
+                    </goals>
+                </execution>
+            </executions>
+        </plugin>
+    </plugins>
   </build>
 
   <dependencies>
@@ -64,5 +86,10 @@
     		<artifactId>morphia</artifactId>
     		<version>0.110</version>
 	</dependency>	
+    <dependency>
+        <groupId>org.jacoco</groupId>
+        <artifactId>jacoco-maven-plugin</artifactId>
+        <version>0.7.5.201505241946</version>
+    </dependency>
   </dependencies>
 </project>


### PR DESCRIPTION
Run `mvn test` and open target/site/jacoco/index.html to see [JaCoCo](http://eclemma.org/jacoco/) code coverage reports like this:

![oncoblocks_-_2015-11-08_20 46 40](https://cloud.githubusercontent.com/assets/21006/11024288/3e3c1f94-865a-11e5-8596-ae9018330a46.png)
